### PR TITLE
Set SecretReference.namespace to omitempty

### DIFF
--- a/api/types/crossplane-runtime/resource.go
+++ b/api/types/crossplane-runtime/resource.go
@@ -50,5 +50,5 @@ type SecretReference struct {
 	Name string `json:"name"`
 
 	// Namespace of the secret.
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 }

--- a/config/crd/bases/terraform.core.oam.dev_configurations.yaml
+++ b/config/crd/bases/terraform.core.oam.dev_configurations.yaml
@@ -58,7 +58,6 @@ spec:
                   type: string
               required:
               - name
-              - namespace
               type: object
           required:
           - variable

--- a/config/crd/bases/terraform.core.oam.dev_providers.yaml
+++ b/config/crd/bases/terraform.core.oam.dev_providers.yaml
@@ -53,7 +53,6 @@ spec:
                   required:
                   - key
                   - name
-                  - namespace
                   type: object
                 source:
                   description: Source of the provider credentials.


### PR DESCRIPTION
In KubeVela, the namespace can be automatically set by vela core,
so set it optional for developer