### PR TITLE
reduce job restarts and pull images

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -301,7 +301,6 @@ func assembleTerraformJob(name, jobName string, configuration *v1beta1.Configura
 	envs []v1.EnvVar, executionType TerraformExecutionType) *batchv1.Job {
 	var parallelism int32 = 1
 	var completions int32 = 1
-	var ttlSecondsAfterFinished int32 = 0
 
 	initContainerVolumeMounts := []v1.VolumeMount{
 		{
@@ -334,8 +333,6 @@ func assembleTerraformJob(name, jobName string, configuration *v1beta1.Configura
 			}},
 		},
 		Spec: batchv1.JobSpec{
-			// TODO(zzxwill) Not enabled in Kubernetes cluster lower than v1.21
-			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 			Parallelism:             &parallelism,
 			Completions:             &completions,
 			Template: v1.PodTemplateSpec{

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -342,7 +342,7 @@ func assembleTerraformJob(name, jobName string, configuration *v1beta1.Configura
 					InitContainers: []v1.Container{{
 						Name:            "prepare-input-terraform-configurations",
 						Image:           terraformInitContainerImg,
-						ImagePullPolicy: v1.PullAlways,
+						ImagePullPolicy: v1.PullIfNotPresent,
 						Command: []string{
 							"sh",
 							"-c",
@@ -355,7 +355,7 @@ func assembleTerraformJob(name, jobName string, configuration *v1beta1.Configura
 					Containers: []v1.Container{{
 						Name:            "terraform-executor",
 						Image:           terraformImage,
-						ImagePullPolicy: v1.PullAlways,
+						ImagePullPolicy: v1.PullIfNotPresent,
 						Command: []string{
 							"bash",
 							"-c",


### PR DESCRIPTION
on testing in an EKS 1.20 ttlSecondsAfterFinished configuration caused the job to be errased and recreated continuosly, this also led to reaching the limit on docker hub pull for the images which is why I updated the PullPolicy

Server version is: Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.4-eks-6b7464", GitCommit:"6b746440c04cb81db4426842b4ae65c3f7035e53", GitTreeState:"clean", BuildDate:"2021-03-19T19:33:03Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}