### PR TITLE
remove owner reference for job

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -324,13 +324,6 @@ func assembleTerraformJob(name, jobName string, configuration *v1beta1.Configura
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: controllerNamespace,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: configuration.APIVersion,
-				Kind:       configuration.Kind,
-				Name:       configuration.Name,
-				UID:        configuration.UID,
-				Controller: pointer.BoolPtr(false),
-			}},
 		},
 		Spec: batchv1.JobSpec{
 			Parallelism:             &parallelism,


### PR DESCRIPTION
when the configuration is outside of the namespace of the job in this case the controllerNamespace,  the owner reference causes de job to be garbage collected and continuosly be recreated