### PR TITLE
Support AWS temporary Session Token

### DIFF
--- a/controllers/util/provider.go
+++ b/controllers/util/provider.go
@@ -38,6 +38,7 @@ const (
 	EnvAWSAccessKeyID     = "AWS_ACCESS_KEY_ID"
 	EnvAWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 	EnvAWSDefaultRegion   = "AWS_DEFAULT_REGION"
+	EnvAWSSessionToken    = "AWS_SESSION_TOKEN"
 
 	EnvGCPCredentialsJSON = "GOOGLE_CREDENTIALS"
 	EnvGCPRegion          = "GOOGLE_REGION"
@@ -64,6 +65,7 @@ type AlibabaCloudCredentials struct {
 type AWSCredentials struct {
 	AWSAccessKeyID     string `yaml:"awsAccessKeyID"`
 	AWSSecretAccessKey string `yaml:"awsSecretAccessKey"`
+	AWSSessionToken    string `yaml:"awsSessionToken"`
 }
 
 type GCPCredentials struct {
@@ -133,6 +135,7 @@ func GetProviderCredentials(ctx context.Context, k8sClient client.Client, namesp
 			return map[string]string{
 				EnvAWSAccessKeyID:     ak.AWSAccessKeyID,
 				EnvAWSSecretAccessKey: ak.AWSSecretAccessKey,
+				EnvAWSSessionToken:    ak.AWSSessionToken,
 				EnvAWSDefaultRegion:   region,
 			}, nil
 		case string(GCP):

--- a/getting-started.md
+++ b/getting-started.md
@@ -227,6 +227,12 @@ Bucket Number is: 0
 
 ```shell
 $ export AWS_ACCESS_KEY_ID=xxx;export AWS_SECRET_ACCESS_KEY=yyy
+```
+
+If you'd like to use AWS session token for temporary credentials, please export `AWS_SESSION_TOKEN`.
+```shell
+$ export AWS_SESSION_TOKEN=zzz
+```
 
 $ sh hack/prepare-aws-credentials.sh
 

--- a/hack/prepare-aws-credentials.sh
+++ b/hack/prepare-aws-credentials.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs
-echo "awsAccessKeyID: ${AWS_ACCESS_KEY_ID}\nawsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}" > aws-credentials.conf
+echo "awsAccessKeyID: ${AWS_ACCESS_KEY_ID}\nawsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}\nawsSessionToken: ${AWS_SESSION_TOKEN}" > aws-credentials.conf
 kubectl create secret generic aws-account-creds -n vela-system --from-file=credentials=aws-credentials.conf
 rm -f aws-credentials.conf


### PR DESCRIPTION
For production-grade security it's recommended to deploy AWS
resources using temporary credentials.

Fix #69