### PR TITLE
Add EC support to Terraform controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Terraform Controller is a Kubernetes Controller for Terraform.
 - [Alibaba Cloud](https://www.alibabacloud.com/)
 - [AWS](https://aws.amazon.com/)
 - [Azure](https://portal.azure.com/)
+- [Elastic Cloud](https://www.elastic.co/)
 - [GCP](https://cloud.google.com/)
 - [VMware vSphere](https://www.vmware.com/hk/products/vsphere.html)
 

--- a/examples/ec/configuration_hcl_ecdeployment.yaml
+++ b/examples/ec/configuration_hcl_ecdeployment.yaml
@@ -4,10 +4,12 @@ metadata:
   name: ec-deployment
 spec:
   hcl: |
-    required_providers {
-      ec = {
-        source  = "elastic/ec"
-        version = "0.2.1"
+    terraform {
+      required_providers {
+        ec = {
+          source  = "elastic/ec"
+          version = "0.2.1"
+        }
       }
     }
 

--- a/examples/ec/configuration_hcl_ecdeployment.yaml
+++ b/examples/ec/configuration_hcl_ecdeployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: ec-deployment
 spec:
   hcl: |
+    required_providers {
+      ec = {
+        source  = "elastic/ec"
+        version = "0.2.1"
+      }
+    }
+
     data "ec_stack" "latest" {
       version_regex = "latest"
       region        = var.ec_region
@@ -12,12 +19,12 @@ spec:
     resource "ec_deployment" "project" {
       name = var.project_name
 
-      region                 = var.region
+      region                 = var.ec_region
       version                 = data.ec_stack.latest.version
       deployment_template_id = "gcp-io-optimized"
 
       elasticsearch {
-        autosccale = "true"
+        autoscale = "true"
       }
 
       kibana {}
@@ -28,7 +35,7 @@ spec:
     }
 
     output "ES_PASSWORD" {
-      value = ec_deployment.project.elasticsearch[0].password
+      value = ec_deployment.project.elasticsearch_password
       sensitive = true
     }
 
@@ -45,3 +52,6 @@ spec:
   writeConnectionSecretToRef:
     name: es-connection
     namespace: default
+
+  providerRef:
+    name: default

--- a/examples/ec/configuration_hcl_ecdeployment.yaml
+++ b/examples/ec/configuration_hcl_ecdeployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: terraform.core.oam.dev/v1beta1
+kind: Configuration
+metadata:
+  name: ec-deployment
+spec:
+  hcl: |
+    data "ec_stack" "latest" {
+      version_regex = "latest"
+      region        = var.ec_region
+    }
+
+    resource "ec_deployment" "project" {
+      name = var.project_name
+
+      region                 = var.region
+      version                 = data.ec_stack.latest.version
+      deployment_template_id = "gcp-io-optimized"
+
+      elasticsearch {
+        autosccale = "true"
+      }
+
+      kibana {}
+    }
+
+    output "ES_HTTPS_ENDPOINT" {
+      value = ec_deployment.project.elasticsearch[0].https_endpoint
+    }
+
+    output "ES_PASSWORD" {
+      value = ec_deployment.project.elasticsearch[0].password
+      sensitive = true
+    }
+
+    variable "ec_region" {
+      default = "gcp-us-west1"
+    }
+
+    variable "project_name" {
+      default = "example"
+    }
+  variable:
+    project_name: "es-project-1"
+
+  writeConnectionSecretToRef:
+    name: es-connection
+    namespace: default

--- a/examples/ec/provider.yaml
+++ b/examples/ec/provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: terraform.core.oam.dev/v1beta1
+kind: Provider
+metadata:
+  name: ec
+spec:
+  provider: ec
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: vela-system
+      name: ec-account-creds
+      key: credentials

--- a/examples/ec/provider.yaml
+++ b/examples/ec/provider.yaml
@@ -1,7 +1,7 @@
 apiVersion: terraform.core.oam.dev/v1beta1
 kind: Provider
 metadata:
-  name: ec
+  name: default
 spec:
   provider: ec
   credentials:

--- a/examples/tf-native/ec/hcl/deployment.tf
+++ b/examples/tf-native/ec/hcl/deployment.tf
@@ -1,0 +1,35 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = var.ec_region
+}
+
+resource "ec_deployment" "project" {
+  name = var.project_name
+
+  region                 = var.region
+  version                 = data.ec_stack.latest.version
+  deployment_template_id = "gcp-io-optimized"
+
+  elasticsearch {
+    autosccale = "true"
+  }
+
+  kibana {}
+}
+
+output "ES_HTTPS_ENDPOINT" {
+  value = ec_deployment.project.elasticsearch[0].https_endpoint
+}
+
+output "ES_PASSWORD" {
+  value = ec_deployment.project.elasticsearch[0].password
+  sensitive = true
+}
+
+variable "ec_region" {
+  default = "gcp-us-west1"
+}
+
+variable "project_name" {
+  default = "example"
+}

--- a/examples/tf-native/ec/hcl/deployment.tf
+++ b/examples/tf-native/ec/hcl/deployment.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = "0.2.1"
+    }
+  }
+}
+
 data "ec_stack" "latest" {
   version_regex = "latest"
   region        = var.ec_region
@@ -6,12 +15,12 @@ data "ec_stack" "latest" {
 resource "ec_deployment" "project" {
   name = var.project_name
 
-  region                 = var.region
+  region                 = var.ec_region
   version                 = data.ec_stack.latest.version
   deployment_template_id = "gcp-io-optimized"
 
   elasticsearch {
-    autosccale = "true"
+    autoscale = "true"
   }
 
   kibana {}
@@ -22,7 +31,7 @@ output "ES_HTTPS_ENDPOINT" {
 }
 
 output "ES_PASSWORD" {
-  value = ec_deployment.project.elasticsearch[0].password
+  value = ec_deployment.project.elasticsearch_password
   sensitive = true
 }
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -496,7 +496,7 @@ vm-outputs   Opaque   1      18m
 
 ### Apply Provider configuration
 
-To interact with the EC Terraform provider an API key is expected. Please see Elastic Cloud documentation for [generating API keys](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restful-api-authentication.html).
+To interact with the EC Terraform provider an API key is expected. Please see Terraform EC provider documentation for [generating API keys](https://registry.terraform.io/providers/elastic/ec/latest/docs).
 ```shell
 $ export EC_API_KEY=xxx
 
@@ -520,6 +520,13 @@ metadata:
   name: ec-deployment
 spec:
   hcl: |
+    required_providers {
+      ec = {
+        source  = "elastic/ec"
+        version = "0.2.1"
+      }
+    }
+
     data "ec_stack" "latest" {
       version_regex = "latest"
       region        = var.ec_region
@@ -528,12 +535,12 @@ spec:
     resource "ec_deployment" "project" {
       name = var.project_name
 
-      region                 = var.region
-      version                 = data.ec_stack.latest.version
+      region                 = var.ec_region
+      version                = data.ec_stack.latest.version
       deployment_template_id = "gcp-io-optimized"
 
       elasticsearch {
-        autosccale = "true"
+        autoscale = "true"
       }
 
       kibana {}
@@ -544,7 +551,7 @@ spec:
     }
 
     output "ES_PASSWORD" {
-      value = ec_deployment.project.elasticsearch[0].password
+      value = ec_deployment.project.elasticsearch_password
       sensitive = true
     }
 
@@ -561,6 +568,9 @@ spec:
   writeConnectionSecretToRef:
     name: es-connection
     namespace: default
+
+  providerRef:
+    name: default
 ```
 
 ```shell

--- a/getting-started.md
+++ b/getting-started.md
@@ -520,10 +520,12 @@ metadata:
   name: ec-deployment
 spec:
   hcl: |
-    required_providers {
-      ec = {
-        source  = "elastic/ec"
-        version = "0.2.1"
+    terraform {
+      required_providers {
+        ec = {
+          source  = "elastic/ec"
+          version = "0.2.1"
+        }
       }
     }
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -496,6 +496,7 @@ vm-outputs   Opaque   1      18m
 
 ### Apply Provider configuration
 
+To interact with the EC Terraform provider an API key is expected. Please see Elastic Cloud documentation for [generating API keys](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restful-api-authentication.html).
 ```shell
 $ export EC_API_KEY=xxx
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -506,7 +506,7 @@ $ kubectl get secret -n vela-system
 NAME                                              TYPE                                  DATA   AGE
 ec-account-creds                                 Opaque                                1      52s
 
-$ k apply -f examples/ec/provider.yaml
+$ kubectl apply -f examples/ec/provider.yaml
 provider.terraform.core.oam.dev/ec created
 ```
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -492,7 +492,7 @@ NAME         TYPE     DATA   AGE
 vm-outputs   Opaque   1      18m
 ```
 
-# For EC
+# For Elastic Cloud
 
 ### Apply Provider configuration
 

--- a/hack/prepare-ec-credentials.sh
+++ b/hack/prepare-ec-credentials.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo "ecApiKey: '${EC_API_KEY}'" > ec-credentials.conf
+echo "ecApiKey: ${EC_API_KEY}" > ec-credentials.conf
 kubectl create secret generic ec-account-creds -n vela-system --from-file=credentials=ec-credentials.conf
 rm -f ec-credentials.conf

--- a/hack/prepare-ec-credentials.sh
+++ b/hack/prepare-ec-credentials.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "ecApiKey: '${EC_API_KEY}'" > ec-credentials.conf
+kubectl create secret generic ec-account-creds -n vela-system --from-file=credentials=ec-credentials.conf
+rm -f ec-credentials.conf


### PR DESCRIPTION
This change adds support for the EC module in terraform-controller. Without this change the EC provider for Elastic Cloud cannot be used via the terraform-controller because it does not know how to find secrets.