### PR TITLE
Fix unit-test issue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,6 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.16.5'
-  KIND_VERSION: 'v0.7.0'
 
 jobs:
   detect-noop:
@@ -59,13 +58,11 @@ jobs:
         run:  |
           sudo apt-get install -y golang-ginkgo-dev
 
-      - name: Setup Kind Cluster
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-
-      - name: install Kubebuilder
-        uses: wonderflow/kubebuilder-action@v1.1
+      - name: Install Kubebuilder
+        run: |
+          wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_linux_amd64.tar.gz
+          tar -zxf kubebuilder_2.3.2_linux_amd64.tar.gz
+          sudo mv kubebuilder_2.3.2_linux_amd64 /usr/local/kubebuilder
 
       - name: Run Make test
         run: make test

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -47,7 +47,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
@@ -69,8 +69,6 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
You are passing a Done channel to a test node to test asynchronous behavior.
This is deprecated in Ginkgo V2.  Your test will run synchronously and
the timeout will be ignored.