### PR TITLE
Fix: fix alibaba cloud rds module

### DIFF
--- a/examples/alibaba/rds/configuration_hcl_rds.yaml
+++ b/examples/alibaba/rds/configuration_hcl_rds.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   hcl: |
     module "rds" {
-      source = "terraform-alicloud-modules/rds/alicloud"
+      source = "github.com/zzxwill/terraform-alicloud-rds"
       engine = "MySQL"
       engine_version = "8.0"
-      instance_type = "rds.mysql.c1.large"
+      instance_type = "rds.mysql.s3.large"
+      instance_storage_type = "local_ssd"
       instance_storage = "20"
       instance_name = var.instance_name
       account_name = var.account_name

--- a/examples/tf-native/alibaba/rds/rds.tf
+++ b/examples/tf-native/alibaba/rds/rds.tf
@@ -1,8 +1,9 @@
 module "rds" {
-  source = "terraform-alicloud-modules/rds/alicloud"
+  source = "github.com/zzxwill/terraform-alicloud-rds"
   engine = "MySQL"
   engine_version = "8.0"
   instance_type = "rds.mysql.c1.large"
+  instance_storage_type = "local_ssd"
   instance_storage = "20"
   instance_name = var.instance_name
   account_name = var.account_name


### PR DESCRIPTION
Enable users to set `db_instance_storage_type`. This can fix the issue
happended since Sept. 14, 2021.
{"Code":"InvalidNetworkTypeClassicWhenCloudStorage","HostId":
"rds.aliyuncs.com","Message":"The Specified InstanceNetworkType
value Classic is not valid when choose cloud storage type."