### PR TITLE
Fix: stop installing golangci-lint each time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,16 +93,20 @@ HOSTARCH := amd64
 endif
 
 golangci:
-ifeq (, $(shell which golangci-lint))
+ifneq ($(shell which golangci-lint),)
+	@$(OK) golangci-lint is already installed
+GOLANGCILINT=$(shell which golangci-lint)
+else ifeq (, $(shell which $(GOBIN)/golangci-lint))
 	@{ \
 	set -e ;\
 	echo 'installing golangci-lint-$(GOLANGCILINT_VERSION)' ;\
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCILINT_VERSION) ;\
-	echo 'Install succeed' ;\
+	echo 'Successfully installed' ;\
 	}
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
-GOLANGCILINT=$(shell which golangci-lint)
+	@$(OK) golangci-lint is already installed
+GOLANGCILINT=$(GOBIN)/golangci-lint
 endif
 
 lint: golangci


### PR DESCRIPTION
When golangci-lint doesn't locate in $PATH, it will be installed in
$GOBIN every single time.