### PR TITLE
Refactor: reorganize the spec of Configuration

### DIFF
--- a/api/types/crossplane-runtime/resource.go
+++ b/api/types/crossplane-runtime/resource.go
@@ -58,7 +58,7 @@ type Reference struct {
 	// Name of the referenced object.
 	Name string `json:"name"`
 
-	// Namespace of the secret.
+	// Namespace of the referenced object.
 	// +kubebuilder:default:=default
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/api/v1beta1/configuration_types.go
+++ b/api/v1beta1/configuration_types.go
@@ -42,20 +42,20 @@ type ConfigurationSpec struct {
 	// still will set by the controller, ignoring the settings in HCL/JSON backend
 	Backend *Backend `json:"backend,omitempty"`
 
-	// WriteConnectionSecretToReference specifies the namespace and name of a
-	// Secret to which any connection details for this managed resource should
-	// be written. Connection details frequently include the endpoint, username,
-	// and password required to connect to the managed resource.
-	// +optional
-	WriteConnectionSecretToReference *types.SecretReference `json:"writeConnectionSecretToRef,omitempty"`
+	// Path is the sub-directory of remote git repository.
+	Path string `json:"path,omitempty"`
 
 	BaseConfigurationSpec `json:",inline"`
 }
 
 // BaseConfigurationSpec defines the common fields of a ConfigurationSpec
 type BaseConfigurationSpec struct {
-	// Path is the sub-directory of remote git repository. It's valid when remote is set
-	Path string `json:"path,omitempty"`
+	// WriteConnectionSecretToReference specifies the namespace and name of a
+	// Secret to which any connection details for this managed resource should
+	// be written. Connection details frequently include the endpoint, username,
+	// and password required to connect to the managed resource.
+	// +optional
+	WriteConnectionSecretToReference *types.SecretReference `json:"writeConnectionSecretToRef,omitempty"`
 
 	// ProviderReference specifies the reference to Provider
 	ProviderReference *types.Reference `json:"providerRef,omitempty"`

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -71,8 +71,7 @@ spec:
                 description: HCL is the Terraform HCL type configuration
                 type: string
               path:
-                description: Path is the sub-directory of remote git repository. It's
-                  valid when remote is set
+                description: Path is the sub-directory of remote git repository.
                 type: string
               providerRef:
                 description: ProviderReference specifies the reference to Provider
@@ -82,7 +81,7 @@ spec:
                     type: string
                   namespace:
                     default: default
-                    description: Namespace of the secret.
+                    description: Namespace of the referenced object.
                     type: string
                 required:
                 - name

--- a/examples/alibaba/oss/configuration_hcl_bucket.yaml
+++ b/examples/alibaba/oss/configuration_hcl_bucket.yaml
@@ -30,7 +30,7 @@ spec:
     inClusterConfig: true
 
   variable:
-    bucket: "vela-website"
+    bucket: "vela-website-20211130-1900"
     acl: "private"
 
   writeConnectionSecretToRef:


### PR DESCRIPTION
Moved `path` out of baseConfiguration and add `writeConnectionSecretToRef`
in baseConfiguration, making baseConfiguration to be able to integrate by
KubeVela.