### PR TITLE
Fix unproper serviceaccount settings

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -440,7 +440,7 @@ func (r *ConfigurationReconciler) preCheck(ctx context.Context, configuration *v
 	}
 
 	// Apply ClusterRole
-	return createTerraformExecutorClusterRole(ctx, k8sClient, ClusterRoleName)
+	return createTerraformExecutorClusterRole(ctx, k8sClient, fmt.Sprintf("%s-%s", meta.Namespace, ClusterRoleName))
 }
 
 func (meta *TFConfigurationMeta) updateApplyStatus(ctx context.Context, k8sClient client.Client, state types.ConfigurationState, message string) error {

--- a/e2e/regression/alibaba_test.go
+++ b/e2e/regression/alibaba_test.go
@@ -46,7 +46,7 @@ func TestConfiguration(t *testing.T) {
 				if len(fields) == 0 {
 					continue
 				}
-				if !(len(fields) == 3 && fields[1] == "Available") {
+				if fields[1] != "Available" {
 					available = false
 					return false
 				}

--- a/e2e/regression/alibaba_test.go
+++ b/e2e/regression/alibaba_test.go
@@ -1,4 +1,4 @@
-package configurations
+package regression
 
 import (
 	"fmt"
@@ -17,9 +17,9 @@ func TestConfiguration(t *testing.T) {
 	It("All Configurations should become `Available`", func() {
 		pwd, _ := os.Getwd()
 		configurations := []string{
-			"examples/alibaba/eip/configuration_eip_remote.yaml",
 			"examples/alibaba/eip/configuration_eip_remote_subdirectory.yaml",
 			"examples/alibaba/rds/configuration_hcl_rds.yaml",
+			"examples/alibaba/oss/configuration_hcl_bucket.yaml",
 		}
 		for _, c := range configurations {
 			cmd := fmt.Sprintf("kubectl apply -f %s", filepath.Join(pwd, "..", "..", c))

--- a/e2e/regression/suite_test.go
+++ b/e2e/regression/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package configurations
+package regression
 
 import (
 	"testing"

--- a/examples/alibaba/eip/configuration_eip_remote_in_another_namespace.yaml
+++ b/examples/alibaba/eip/configuration_eip_remote_in_another_namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: terraform.core.oam.dev/v1beta1
+kind: Configuration
+metadata:
+  name: alibaba-remote-eip-in-another-namespace
+  namespace: abc
+spec:
+  remote: https://github.com/zzxwill/terraform-alibaba-eip.git
+
+  variable:
+    name: poc-remote
+    bandwidth: 1
+
+  writeConnectionSecretToRef:
+    name: eip-remote-conn
+    namespace: default


### PR DESCRIPTION
When there are two applications, who have the same application name, but
different namespace names, the second one's service account will use
the first one. But the clusterrole's namespace isn't in its namespace.
It will lack all authority to perform any operations when running
Terraform applying.

Fix #192

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>