### PR TITLE
Validate Alibaba credentials ak/sk/ststoken

### DIFF
--- a/controllers/provider/credentials.go
+++ b/controllers/provider/credentials.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aliyun/alibaba-cloud-sdk-go/services/ram"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -268,23 +268,23 @@ func GetProviderFromConfiguration(ctx context.Context, k8sClient client.Client, 
 // checkAlibabaCloudProvider checks if the credentials from the provider are valid
 func checkAlibabaCloudCredentials(region string, accessKeyID, accessKeySecret, stsToken string) error {
 	var (
-		client *ram.Client
+		client *sts.Client
 		err    error
 	)
 	if stsToken != "" {
-		client, err = ram.NewClientWithStsToken(region, accessKeyID, accessKeySecret, stsToken)
+		client, err = sts.NewClientWithStsToken(region, accessKeyID, accessKeySecret, stsToken)
 	} else {
-		client, err = ram.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+		client, err = sts.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
 	}
 	if err != nil {
 		return err
 	}
-	request := ram.CreateGetPasswordPolicyRequest()
+	request := sts.CreateGetCallerIdentityRequest()
 	request.Scheme = "https"
 
-	_, err = client.GetPasswordPolicy(request)
+	_, err = client.GetCallerIdentity(request)
 	if err != nil {
-		errMsg := "Alibaba Cloud credentials are not valid"
+		errMsg := "Alibaba Cloud credentials are invalid"
 		klog.ErrorS(err, errMsg)
 		return errors.Wrap(err, errMsg)
 	}

--- a/controllers/provider/credentials_test.go
+++ b/controllers/provider/credentials_test.go
@@ -24,6 +24,16 @@ func TestCheckAlibabaCloudCredentials(t *testing.T) {
 			name: "Check AlibabaCloud credentials",
 			args: args{
 				credentials: credentials{
+					AccessKeyID:     "aaaa",
+					AccessKeySecret: "bbbbb",
+					Region:          "cn-hangzhou",
+				},
+			},
+		},
+		{
+			name: "Check AlibabaCloud credentials with sts token",
+			args: args{
+				credentials: credentials{
 					AccessKeyID:     "STS.aaaa",
 					AccessKeySecret: "bbbbb",
 					SecurityToken:   "ccc",

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,17 @@ go 1.16
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1318
+	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1384
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/google/go-cmp v0.5.5
+	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
 	github.com/pkg/errors v0.9.1
+	github.com/smartystreets/assertions v1.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	google.golang.org/appengine v1.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/aliyun/alibaba-cloud-sdk-go v1.61.1318 h1:5/KrzvOaL+OkOi0/AObUXijCA6HubAi6C2hc+7smbXA=
-github.com/aliyun/alibaba-cloud-sdk-go v1.61.1318/go.mod h1:9CMdKNL3ynIGPpfTcdwTvIm8SGuAZYYC4jFVSSvE1YQ=
+github.com/aliyun/alibaba-cloud-sdk-go v1.61.1384 h1:hJm7oFzY49BcC2Kd5o8tyDWv3xFNop6bTmon9phd74w=
+github.com/aliyun/alibaba-cloud-sdk-go v1.61.1384/go.mod h1:9CMdKNL3ynIGPpfTcdwTvIm8SGuAZYYC4jFVSSvE1YQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -208,8 +208,9 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
+github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -344,8 +345,9 @@ github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
+github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
Change the API to validate Alibaba credentials, including ak, sk
and ststoken.

This precious API needs RAM polocies and will hit the issue
https://github.com/oam-dev/kubevela/issues/2917

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>