### PR TITLE
Replace GitHub with Gitee when GitHub is blocked

### DIFF
--- a/chart/templates/terraform_controller.yaml
+++ b/chart/templates/terraform_controller.yaml
@@ -33,4 +33,6 @@ spec:
               value: {{ .Values.busyboxImage}}
             - name: GIT_IMAGE
               value: {{ .Values.gitImage}}
+            - name: GITHUB_BLOCKED
+              value: {{ .Values.githubBlocked }}
       serviceAccountName: tf-controller-service-account

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,3 +11,5 @@ terraformImage: oamdev/docker-terraform:1.0.9
 
 backend:
   namespace: vela-system
+
+githubBlocked: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
         threshold: 0.1%
     patch:
       default:
-        target: 5%
+        target: 80%

--- a/controllers/configuration/configuration_test.go
+++ b/controllers/configuration/configuration_test.go
@@ -1,1 +1,53 @@
 package configuration
+
+import (
+	"testing"
+)
+
+func TestReplaceTerraformSource(t *testing.T) {
+	testcases := []struct {
+		remote        string
+		githubBlocked string
+		expected      string
+	}{
+		{
+			remote:        "",
+			expected:      "",
+			githubBlocked: "xxx",
+		},
+		{
+			remote:        "https://github.com/kubevela-contrib/terraform-modules.git",
+			expected:      "https://github.com/kubevela-contrib/terraform-modules.git",
+			githubBlocked: "false",
+		},
+		{
+			remote:        "https://github.com/kubevela-contrib/terraform-modules.git",
+			githubBlocked: "true",
+			expected:      "https://gitee.com/kubevela-contrib/terraform-modules.git",
+		},
+		{
+			remote:        "abc",
+			githubBlocked: "true",
+			expected:      "abc",
+		},
+		{
+			remote:        "",
+			githubBlocked: "true",
+			expected:      "",
+		},
+		{
+			remote:        "https://github.com-https://github.com",
+			githubBlocked: "true",
+			expected:      "https://gitee.com-https://github.com",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.remote, func(t *testing.T) {
+			actual := ReplaceTerraformSource(tc.remote, tc.githubBlocked)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -106,6 +106,9 @@ var (
 
 	busyboxImage = os.Getenv("BUSYBOX_IMAGE")
 	gitImage     = os.Getenv("GIT_IMAGE")
+
+	// githubBlocked mark whether GitHub is blocked in the cluster
+	githubBlocked = os.Getenv("GITHUB_BLOCKED")
 )
 
 // TFConfigurationMeta is all the metadata of a Configuration
@@ -225,7 +228,7 @@ func initTFConfigurationMeta(req ctrl.Request, configuration v1beta1.Configurati
 		DestroyJobName:      req.Name + "-" + string(TerraformDestroy),
 	}
 
-	meta.RemoteGit = configuration.Spec.Remote
+	meta.RemoteGit = tfcfg.ReplaceTerraformSource(configuration.Spec.Remote, githubBlocked)
 	meta.DeleteResource = configuration.Spec.DeleteResource
 	if configuration.Spec.Path == "" {
 		meta.RemoteGitPath = "."

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1,0 +1,90 @@
+package controllers
+
+import (
+	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
+	"github.com/oam-dev/terraform-controller/api/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"testing"
+)
+
+func TestInitTFConfigurationMeta(t *testing.T) {
+	req := ctrl.Request{}
+	req.Namespace = "default"
+	req.Name = "abc"
+
+	completeConfiguration := v1beta1.Configuration{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: v1beta1.ConfigurationSpec{
+			Path: "alibaba/rds",
+			Backend: &v1beta1.Backend{
+				SecretSuffix: "s1",
+			},
+		},
+	}
+	completeConfiguration.Spec.ProviderReference = &crossplane.Reference{
+		Name:      "xxx",
+		Namespace: "default",
+	}
+
+	testcases := []struct {
+		name          string
+		configuration v1beta1.Configuration
+		want          *TFConfigurationMeta
+	}{
+		{
+			name: "empty configuration",
+			configuration: v1beta1.Configuration{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			want: &TFConfigurationMeta{
+				Namespace:           "default",
+				Name:                "abc",
+				ConfigurationCMName: "tf-abc",
+				VariableSecretName:  "variable-abc",
+				ApplyJobName:        "abc-apply",
+				DestroyJobName:      "abc-destroy",
+
+				RemoteGitPath: ".",
+				ProviderReference: &crossplane.Reference{
+					Name:      "default",
+					Namespace: "default",
+				},
+				BackendSecretName: "tfstate-default-abc",
+			},
+		},
+		{
+			name:          "complete configuration",
+			configuration: completeConfiguration,
+			want: &TFConfigurationMeta{
+				Namespace:           "default",
+				Name:                "abc",
+				ConfigurationCMName: "tf-abc",
+				VariableSecretName:  "variable-abc",
+				ApplyJobName:        "abc-apply",
+				DestroyJobName:      "abc-destroy",
+
+				RemoteGitPath: "alibaba/rds",
+				ProviderReference: &crossplane.Reference{
+					Name:      "xxx",
+					Namespace: "default",
+				},
+				BackendSecretName: "tfstate-default-s1",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := initTFConfigurationMeta(req, tc.configuration)
+			if !reflect.DeepEqual(meta.Name, tc.want.Name) {
+				t.Errorf("initTFConfigurationMeta = %v, want %v", meta, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When Github is blocked, replace Github with Gitee where Terraform
modules are stored.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>