### PR TITLE
Deprecate spec.JSON in Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Terraform Controller is a Kubernetes Controller for Terraform.
 ## Supported Terraform Configuration
 
 - HCL
-- JSON
+- JSON (Deprecated in v0.3.1)
 
 # Get started
 

--- a/api/v1beta1/configuration_types.go
+++ b/api/v1beta1/configuration_types.go
@@ -17,16 +17,17 @@ limitations under the License.
 package v1beta1
 
 import (
-	state "github.com/oam-dev/terraform-controller/api/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	state "github.com/oam-dev/terraform-controller/api/types"
 	types "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 )
 
 // ConfigurationSpec defines the desired state of Configuration
 type ConfigurationSpec struct {
-	// JSON is the Terraform JSON syntax configuration
+	// JSON is the Terraform JSON syntax configuration.
+	// Deprecated: after v0.3.1, use HCL instead.
 	JSON string `json:"JSON,omitempty"`
 	// HCL is the Terraform HCL type configuration
 	HCL string `json:"hcl,omitempty"`

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -44,7 +44,8 @@ spec:
             description: ConfigurationSpec defines the desired state of Configuration
             properties:
               JSON:
-                description: JSON is the Terraform JSON syntax configuration
+                description: 'JSON is the Terraform JSON syntax configuration. Deprecated:
+                  after v0.3.1, use HCL instead.'
                 type: string
               backend:
                 description: Backend stores the state in a Kubernetes secret with


### PR DESCRIPTION
Deprecated spec.JSON and only support HCL in Configuration, as few
users use JSON in Configuration

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>