### PR TITLE
Fix: check whether variables are changed

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -543,12 +543,17 @@ func (meta *TFConfigurationMeta) updateTerraformJobIfNeeded(ctx context.Context,
 
 	var envChanged bool
 	for k, v := range variableInSecret.Data {
+		if len(variableInSecret.Data) != len(meta.VariableSecretData) {
+			envChanged = true
+			break
+		}
 		if val, ok := meta.VariableSecretData[k]; !ok || !bytes.Equal(v, val) {
 			envChanged = true
 			klog.Info("Job's env changed")
 			if err := meta.updateApplyStatus(ctx, k8sClient, types.ConfigurationReloading, types.ConfigurationReloadingAsVariableChanged); err != nil {
 				return err
 			}
+			break
 		}
 	}
 


### PR DESCRIPTION
When whether the properties from Configuration is equal to the ones
stored in ConfigMap, reset the ConfigMap and delete the Job if not.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>