### PR TITLE
Fix: Avoid writing connection string to a same secret

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -808,10 +808,16 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 			}
 		}
 	} else {
-		if owner, ok := gotSecret.ObjectMeta.Labels["terraform-controller-owner"]; ok && owner != configurationName {
-			return nil, fmt.Errorf(
+		// check the owner of this secret
+		labels := gotSecret.ObjectMeta.Labels
+		if owner, ok := labels["terraform-controller-owner"]; ok && owner != configurationName {
+			errMsg := fmt.Sprintf(
 				"configuration(%s) cannot update secret(%s) which owner is configuration(%s)",
-				configurationName, name, owner)
+				configurationName,
+				name,
+				owner,
+			)
+			return nil, errors.New(errMsg)
 		}
 		gotSecret.Data = data
 		if err := k8sClient.Update(ctx, &gotSecret); err != nil {

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -815,7 +815,7 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 		ownerNamespace := labels["owned-namespace"]
 		if configurationName != ownerName || configuration.Namespace != ownerNamespace {
 			errMsg := fmt.Sprintf(
-				"configuration(%s-%s) cannot update secret(%s) which owner is configuration(%s-%s)",
+				"configuration(%s-%s) cannot update secret(%s) whose owner is configuration(%s-%s)",
 				configuration.Namespace, configurationName,
 				name,
 				ownerNamespace, ownerName,

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -793,8 +793,8 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 					Name:      name,
 					Namespace: ns,
 					Labels: map[string]string{
-						"created-by":                 "terraform-controller",
-						"terraform-controller-owner": configurationName,
+						"created-by": "terraform-controller",
+						"owned-by":   configurationName,
 					},
 				},
 				TypeMeta: metav1.TypeMeta{Kind: "Secret"},
@@ -810,7 +810,7 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 	} else {
 		// check the owner of this secret
 		labels := gotSecret.ObjectMeta.Labels
-		if owner, ok := labels["terraform-controller-owner"]; ok && owner != configurationName {
+		if owner, ok := labels["owned-by"]; ok && owner != configurationName {
 			errMsg := fmt.Sprintf(
 				"configuration(%s) cannot update secret(%s) which owner is configuration(%s)",
 				configurationName,

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -809,7 +809,9 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 		}
 	} else {
 		if owner, ok := gotSecret.ObjectMeta.Labels["terraform-controller-owner"]; ok && owner != configurationName {
-			return nil, fmt.Errorf("configuration(%s) cannot update secret(%s) which owner is configuration(%s)", configurationName, name, owner)
+			return nil, fmt.Errorf(
+				"configuration(%s) cannot update secret(%s) which owner is configuration(%s)",
+				configurationName, name, owner)
 		}
 		gotSecret.Data = data
 		if err := k8sClient.Update(ctx, &gotSecret); err != nil {

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1175,7 +1175,7 @@ func TestGetTFOutputs(t *testing.T) {
 			},
 			want: want{
 				property: nil,
-				errMsg:   "configuration(default-configuration6) cannot update secret(connection-secret-e) which owner is configuration(default-configuration5)",
+				errMsg:   "configuration(default-configuration6) cannot update secret(connection-secret-e) whose owner is configuration(default-configuration5)",
 			},
 		},
 		"update a connectionSecret belong to another configuration(same name but different namespace": {
@@ -1187,7 +1187,7 @@ func TestGetTFOutputs(t *testing.T) {
 			},
 			want: want{
 				property: nil,
-				errMsg:   "configuration(b-configuration6) cannot update secret(connection-secret-e) which owner is configuration(a-configuration6)",
+				errMsg:   "configuration(b-configuration6) cannot update secret(connection-secret-e) whose owner is configuration(a-configuration6)",
 			},
 		},
 	}

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -985,8 +985,8 @@ func TestGetTFOutputs(t *testing.T) {
 			Name:      "connection-secret-d",
 			Namespace: "default",
 			Labels: map[string]string{
-				"created-by":                 "terraform-controller",
-				"terraform-controller-owner": "configuration5",
+				"created-by": "terraform-controller",
+				"owned-by":   "configuration5",
 			},
 		},
 		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
@@ -1028,8 +1028,8 @@ func TestGetTFOutputs(t *testing.T) {
 			Name:      "connection-secret-e",
 			Namespace: "default",
 			Labels: map[string]string{
-				"created-by":                 "terraform-controller",
-				"terraform-controller-owner": "configuration5",
+				"created-by": "terraform-controller",
+				"owned-by":   "configuration5",
 			},
 		},
 		TypeMeta: metav1.TypeMeta{Kind: "Secret"},

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -5,11 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/oam-dev/terraform-controller/api/v1beta1"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/oam-dev/terraform-controller/api/v1beta1"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
@@ -25,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	runtimetypes "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 
 	"github.com/oam-dev/terraform-controller/api/types"
 	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
@@ -913,6 +916,146 @@ func TestGetTFOutputs(t *testing.T) {
 		TerraformBackendNamespace: "default",
 	}
 
+	tfStateData, _ := base64.StdEncoding.DecodeString("H4sIAAAAAAAA/4SQzarbMBCF934KoXUdPKNf+1VKCWNp5AocO8hyaSl592KlcBd3cZfnHPHpY/52QshfXI68b3IS+tuVK5dCaS+P+8ci4TbcULb94JJplZPAFte8MS18PQrKBO8Q+xk59SHa1AMA9M4YmoN3FGJ8M/azPs96yElcCkLIsG+V8sblnqOc3uXlRuvZ0GxSSuiCRUYbw2gGHRFGPxitEgJYQDQ0a68I2ChNo1cAZJ2bR20UtW8bsv55NuJRS94W2erXe5X5QQs3A/FZ4fhJaOwUgZTVMRjto1HGpSGSQuuD955hdDDPcR6NY1ZpQJ/YwagTRAvBpsi8LXn7Pa1U+ahfWHX/zWThYz9L4Otg3390r+5fAAAA//8hmcuNuQEAAA==")
+	tfStateOutputs := map[string]v1beta2.Property{
+		"container_id": {
+			Value: "e5fff27c62e26dc9504d21980543f21161225ab483a1e534a98311a677b9453a",
+			Type:  "string",
+		},
+		"image_id": {
+			Value: "sha256:d1a364dc548d5357f0da3268c888e1971bbdb957ee3f028fe7194f1d61c6fdeenginx:latest",
+			Type:  "string",
+		},
+	}
+
+	secret3 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "b",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			TerraformStateNameInSecret: tfStateData,
+		},
+	}
+	k8sClient3 := fake.NewClientBuilder().WithObjects(secret3).Build()
+	meta3 := &TFConfigurationMeta{
+		BackendSecretName:         "b",
+		TerraformBackendNamespace: "default",
+	}
+
+	secret4 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "c",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			TerraformStateNameInSecret: tfStateData,
+		},
+	}
+	k8sClient4 := fake.NewClientBuilder().WithObjects(secret4).Build()
+	configuration4 := v1beta2.Configuration{
+		Spec: v1beta2.ConfigurationSpec{
+			BaseConfigurationSpec: v1beta2.BaseConfigurationSpec{
+				WriteConnectionSecretToReference: &runtimetypes.SecretReference{
+					Name:      "connection-secret-c",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+	meta4 := &TFConfigurationMeta{
+		BackendSecretName:         "c",
+		TerraformBackendNamespace: "default",
+	}
+
+	secret5 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "d",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			TerraformStateNameInSecret: tfStateData,
+		},
+	}
+	oldConnectionSecret5 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "connection-secret-d",
+			Namespace: "default",
+			Labels: map[string]string{
+				"created-by":                 "terraform-controller",
+				"terraform-controller-owner": "configuration5",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
+		Data: map[string][]byte{
+			"container_id": []byte("something"),
+		},
+	}
+	k8sClient5 := fake.NewClientBuilder().WithObjects(secret5, oldConnectionSecret5).Build()
+	configuration5 := v1beta2.Configuration{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "configuration5",
+		},
+		Spec: v1beta2.ConfigurationSpec{
+			BaseConfigurationSpec: v1beta2.BaseConfigurationSpec{
+				WriteConnectionSecretToReference: &runtimetypes.SecretReference{
+					Name:      "connection-secret-d",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+	meta5 := &TFConfigurationMeta{
+		BackendSecretName:         "d",
+		TerraformBackendNamespace: "default",
+	}
+
+	secret6 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			TerraformStateNameInSecret: tfStateData,
+		},
+	}
+	oldConnectionSecret6 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "connection-secret-e",
+			Namespace: "default",
+			Labels: map[string]string{
+				"created-by":                 "terraform-controller",
+				"terraform-controller-owner": "configuration5",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{Kind: "Secret"},
+		Data: map[string][]byte{
+			"container_id": []byte("something"),
+		},
+	}
+	k8sClient6 := fake.NewClientBuilder().WithObjects(secret6, oldConnectionSecret6).Build()
+	configuration6 := v1beta2.Configuration{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "configuration6",
+		},
+		Spec: v1beta2.ConfigurationSpec{
+			BaseConfigurationSpec: v1beta2.BaseConfigurationSpec{
+				WriteConnectionSecretToReference: &runtimetypes.SecretReference{
+					Name:      "connection-secret-e",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+	meta6 := &TFConfigurationMeta{
+		BackendSecretName:         "e",
+		TerraformBackendNamespace: "default",
+	}
+
 	testcases := map[string]struct {
 		args args
 		want want
@@ -937,6 +1080,53 @@ func TestGetTFOutputs(t *testing.T) {
 			want: want{
 				property: nil,
 				errMsg:   "failed to get tfstate from Terraform State secret",
+			},
+		},
+		"some data in a backend secret": {
+			args: args{
+				ctx:       ctx,
+				k8sClient: k8sClient3,
+				meta:      meta3,
+			},
+			want: want{
+				property: tfStateOutputs,
+				errMsg:   "",
+			},
+		},
+		"some data in a backend secret and creates a connectionSecret": {
+			args: args{
+				ctx:           ctx,
+				k8sClient:     k8sClient4,
+				configuration: configuration4,
+				meta:          meta4,
+			},
+			want: want{
+				property: tfStateOutputs,
+				errMsg:   "",
+			},
+		},
+		"some data in a backend secret and update a connectionSecret belong to the same configuration": {
+			args: args{
+				ctx:           ctx,
+				k8sClient:     k8sClient5,
+				configuration: configuration5,
+				meta:          meta5,
+			},
+			want: want{
+				property: tfStateOutputs,
+				errMsg:   "",
+			},
+		},
+		"some data in a backend secret and update a connectionSecret belong to another configuration": {
+			args: args{
+				ctx:           ctx,
+				k8sClient:     k8sClient6,
+				configuration: configuration6,
+				meta:          meta6,
+			},
+			want: want{
+				property: nil,
+				errMsg:   "configuration(configuration6) cannot update secret(connection-secret-e) which owner is configuration(configuration5)",
 			},
 		},
 	}


### PR DESCRIPTION
This pr fixes #152 .

Signed-off-by: loheagn <loheagn@icloud.com>