### PR TITLE
fix: Filter logs from container for terraform jobs

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -60,6 +60,8 @@ const (
 	InputTFConfigurationVolumeMountPath = "/opt/tf-configuration"
 	// BackendVolumeMountPath is the volume mount path for Terraform backend
 	BackendVolumeMountPath = "/opt/tf-backend"
+	// terraformContainerName is the name of the container that executes the terraform in the pod
+	terraformContainerName = "terraform-executor"
 )
 
 const (
@@ -142,7 +144,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// terraform destroy
 		klog.InfoS("performing Configuration Destroy", "Namespace", req.Namespace, "Name", req.Name, "JobName", meta.DestroyJobName)
 
-		_, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.DestroyJobName, meta.TerraformContainerName)
+		_, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.DestroyJobName, terraformContainerName)
 		if err != nil {
 			klog.ErrorS(err, "Terraform destroy failed")
 			if updateErr := meta.updateDestroyStatus(ctx, r.Client, types.ConfigurationDestroyFailed, err.Error()); updateErr != nil {
@@ -173,7 +175,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		return ctrl.Result{RequeueAfter: 3 * time.Second}, errors.Wrap(err, "failed to create/update cloud resource")
 	}
-	state, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.ApplyJobName, meta.TerraformContainerName)
+	state, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.ApplyJobName, terraformContainerName)
 	if err != nil {
 		klog.ErrorS(err, "Terraform apply failed")
 		if updateErr := meta.updateApplyStatus(ctx, r.Client, state, err.Error()); updateErr != nil {
@@ -205,9 +207,7 @@ type TFConfigurationMeta struct {
 	Credentials           map[string]string
 
 	// TerraformImage is the Terraform image which can run `terraform init/plan/apply`
-	TerraformImage string
-	// TerraformContainerName is the name of the container that executes the terraform in the pod
-	TerraformContainerName    string
+	TerraformImage            string
 	TerraformBackendNamespace string
 	BusyboxImage              string
 	GitImage                  string
@@ -215,13 +215,12 @@ type TFConfigurationMeta struct {
 
 func initTFConfigurationMeta(req ctrl.Request, configuration v1beta1.Configuration) *TFConfigurationMeta {
 	var meta = &TFConfigurationMeta{
-		Namespace:              req.Namespace,
-		Name:                   req.Name,
-		ConfigurationCMName:    fmt.Sprintf(TFInputConfigMapName, req.Name),
-		VariableSecretName:     fmt.Sprintf(TFVariableSecret, req.Name),
-		ApplyJobName:           req.Name + "-" + string(TerraformApply),
-		DestroyJobName:         req.Name + "-" + string(TerraformDestroy),
-		TerraformContainerName: "terraform-executor",
+		Namespace:           req.Namespace,
+		Name:                req.Name,
+		ConfigurationCMName: fmt.Sprintf(TFInputConfigMapName, req.Name),
+		VariableSecretName:  fmt.Sprintf(TFVariableSecret, req.Name),
+		ApplyJobName:        req.Name + "-" + string(TerraformApply),
+		DestroyJobName:      req.Name + "-" + string(TerraformDestroy),
 	}
 
 	// githubBlocked mark whether GitHub is blocked in the cluster
@@ -651,7 +650,7 @@ func (meta *TFConfigurationMeta) assembleTerraformJob(executionType TerraformExe
 					// Container terraform-executor will first copy predefined terraform.d to working directory, and
 					// then run terraform init/apply.
 					Containers: []v1.Container{{
-						Name:            meta.TerraformContainerName,
+						Name:            terraformContainerName,
 						Image:           meta.TerraformImage,
 						ImagePullPolicy: v1.PullIfNotPresent,
 						Command: []string{

--- a/controllers/terraform/logging.go
+++ b/controllers/terraform/logging.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func getPodLog(ctx context.Context, client kubernetes.Interface, namespace, jobName string) (string, error) {
+func getPodLog(ctx context.Context, client kubernetes.Interface, namespace, jobName, containerName string) (string, error) {
 	label := fmt.Sprintf("job-name=%s", jobName)
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
 	if err != nil || pods == nil || len(pods.Items) == 0 {
@@ -25,7 +25,7 @@ func getPodLog(ctx context.Context, client kubernetes.Interface, namespace, jobN
 		return "", nil
 	}
 
-	req := client.CoreV1().Pods(namespace).GetLogs(pod.Name, &v1.PodLogOptions{})
+	req := client.CoreV1().Pods(namespace).GetLogs(pod.Name, &v1.PodLogOptions{Container: containerName})
 	logs, err := req.Stream(ctx)
 	if err != nil {
 		return "", err

--- a/controllers/terraform/logging_test.go
+++ b/controllers/terraform/logging_test.go
@@ -21,9 +21,10 @@ import (
 func TestGetPodLog(t *testing.T) {
 	ctx := context.Background()
 	type args struct {
-		client    kubernetes.Interface
-		namespace string
-		name      string
+		client        kubernetes.Interface
+		namespace     string
+		name          string
+		containerName string
 	}
 	type want struct {
 		log    string
@@ -74,9 +75,10 @@ func TestGetPodLog(t *testing.T) {
 		{
 			name: "Pod is available, but no logs",
 			args: args{
-				client:    k8sClientSet,
-				namespace: "default",
-				name:      "j1",
+				client:        k8sClientSet,
+				namespace:     "default",
+				name:          "j1",
+				containerName: "terraform-executor",
 			},
 			want: want{
 				errMsg: "can not be accept",
@@ -85,7 +87,7 @@ func TestGetPodLog(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := getPodLog(ctx, tc.args.client, tc.args.namespace, tc.args.name)
+			got, err := getPodLog(ctx, tc.args.client, tc.args.namespace, tc.args.name, tc.args.containerName)
 			if tc.want.errMsg != "" {
 				assert.EqualError(t, err, tc.want.errMsg)
 			} else {

--- a/controllers/terraform/status.go
+++ b/controllers/terraform/status.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetTerraformStatus will get Terraform execution status
-func GetTerraformStatus(ctx context.Context, namespace, jobName string) (types.ConfigurationState, error) {
+func GetTerraformStatus(ctx context.Context, namespace, jobName, containerName string) (types.ConfigurationState, error) {
 	klog.InfoS("checking Terraform execution status", "Namespace", namespace, "Job", jobName)
 	clientSet, err := client.Init()
 	if err != nil {
@@ -20,7 +20,7 @@ func GetTerraformStatus(ctx context.Context, namespace, jobName string) (types.C
 		return types.ConfigurationProvisioningAndChecking, err
 	}
 
-	logs, err := getPodLog(ctx, clientSet, namespace, jobName)
+	logs, err := getPodLog(ctx, clientSet, namespace, jobName, containerName)
 	if err != nil {
 		klog.ErrorS(err, "failed to get pod logs")
 		return types.ConfigurationProvisioningAndChecking, err

--- a/controllers/terraform/status_test.go
+++ b/controllers/terraform/status_test.go
@@ -16,8 +16,9 @@ import (
 func TestGetTerraformStatus(t *testing.T) {
 	ctx := context.Background()
 	type args struct {
-		namespace string
-		name      string
+		namespace     string
+		name          string
+		containerName string
 	}
 	type want struct {
 		state  types.ConfigurationState
@@ -36,8 +37,9 @@ func TestGetTerraformStatus(t *testing.T) {
 		{
 			name: "logs are not available",
 			args: args{
-				namespace: "default",
-				name:      "test",
+				namespace:     "default",
+				name:          "test",
+				containerName: "terraform-executor",
 			},
 			want: want{
 				state:  types.ConfigurationProvisioningAndChecking,
@@ -47,7 +49,7 @@ func TestGetTerraformStatus(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name)
+			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.containerName)
 			if tc.want.errMsg != "" {
 				assert.EqualError(t, err, tc.want.errMsg)
 			} else {
@@ -61,8 +63,9 @@ func TestGetTerraformStatus(t *testing.T) {
 func TestGetTerraformStatus2(t *testing.T) {
 	ctx := context.Background()
 	type args struct {
-		namespace string
-		name      string
+		namespace     string
+		name          string
+		containerName string
 	}
 	type want struct {
 		state  types.ConfigurationState
@@ -89,7 +92,7 @@ func TestGetTerraformStatus2(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name)
+			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.containerName)
 			if tc.want.errMsg != "" {
 				assert.Contains(t, err.Error(), tc.want.errMsg)
 			} else {


### PR DESCRIPTION
This fixes the issue in case there are other auto injected side cars to the pods created by Jobs. For eg: istio-proxy. This doesnt however fix the issue where istio proxy continues to run even when the "terraform-executor" has completed without the correct label being transferred to the Job template eg: `sidecar.istio.io/inject: "false"`. This does however fix the issue where the getLogs method gives this error for the status because there are multiple containers in the job pod:
`a container name must be specified for pod my-s3-1-apply-5gkzx, choose one of: [prepare-input-terraform-configurations istio-init terraform-executor istio-proxy]`