### PR TITLE
Refactor: modify DeleteResource to bool pointer

### DIFF
--- a/api/v1beta1/configuration_types.go
+++ b/api/v1beta1/configuration_types.go
@@ -63,7 +63,7 @@ type BaseConfigurationSpec struct {
 
 	// DeleteResource will determine whether provisioned cloud resources will be deleted when CR is deleted
 	// +kubebuilder:default:=true
-	DeleteResource bool `json:"deleteResource,omitempty"`
+	DeleteResource *bool `json:"deleteResource,omitempty"`
 
 	// Region is cloud provider's region. It will override the region in the region field of ProviderReference
 	Region string `json:"region,omitempty"`

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -201,7 +201,7 @@ type TFConfigurationMeta struct {
 	ProviderReference     *crossplane.Reference
 	VariableSecretName    string
 	VariableSecretData    map[string][]byte
-	DeleteResource        bool
+	DeleteResource        *bool
 	Credentials           map[string]string
 
 	// TerraformImage is the Terraform image which can run `terraform init/plan/apply`
@@ -298,7 +298,7 @@ func (r *ConfigurationReconciler) terraformDestroy(ctx context.Context, namespac
 		return err
 	}
 
-	deleteConfigurationDirectly := deletable || !meta.DeleteResource
+	deleteConfigurationDirectly := deletable || !(meta.DeleteResource != nil && *meta.DeleteResource)
 
 	if !deleteConfigurationDirectly {
 		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.DestroyJobName, Namespace: meta.Namespace}, &destroyJob); err != nil {

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -443,7 +443,7 @@ func TestTerraformDestroy(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "tf-abc",
 					Namespace:           "default",
-					DeleteResource:      true,
+					DeleteResource:      &[]bool{true}[0],
 				},
 			},
 			want: want{


### PR DESCRIPTION
I want to fix the deleteResource meta in Vela.

https://github.com/oam-dev/terraform-controller/blob/master/api/v1beta1/configuration_types.go#L65

False is the empty value in go, so it is always true.