### PR TITLE
Removed `type` from outputs

### DIFF
--- a/api/v1beta2/configuration_types.go
+++ b/api/v1beta2/configuration_types.go
@@ -97,7 +97,6 @@ type ConfigurationDestroyStatus struct {
 // Property is the property for an output
 type Property struct {
 	Value string `json:"value,omitempty"`
-	Type  string `json:"type,omitempty"`
 }
 
 // Backend stores the state in a Kubernetes secret with locking done using a Lease resource.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: terraform-controller
 version: 0.2.8
 description: A Kubernetes Terraform controller
 home: https://github.com/oam-dev/terraform-controller
-appVersion: "0.3.1"
+appVersion: "0.3.2"

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -272,8 +272,6 @@ spec:
                     additionalProperties:
                       description: Property is the property for an output
                       properties:
-                        type:
-                          type: string
                         value:
                           type: string
                       type: object

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -717,7 +717,7 @@ func (meta *TFConfigurationMeta) createTFBackendVolume() v1.Volume {
 // TfStateProperty is the tf state property for an output
 type TfStateProperty struct {
 	Value interface{} `json:"value,omitempty"`
-	Type  string      `json:"type,omitempty"`
+	Type  interface{} `json:"type,omitempty"`
 }
 
 // ToProperty converts TfStateProperty type to Property
@@ -728,10 +728,9 @@ func (tp *TfStateProperty) ToProperty() (v1beta2.Property, error) {
 	)
 	sv, err := tfcfg.Interface2String(tp.Value)
 	if err != nil {
-		return property, errors.Wrap(err, "failed to get terraform state outputs")
+		return property, errors.Wrapf(err, "failed to convert value %s of terraform state outputs to string", tp.Value)
 	}
 	property = v1beta2.Property{
-		Type:  tp.Type,
 		Value: sv,
 	}
 	return property, err


### PR DESCRIPTION
Here are two drawbacks of exposing type in outputs.
- it’s in Terraform context, not friendly to Golang/Kubernetes
- it’s complicated

Fix #274

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>
