### PR TITLE
Update the error string reported when different configurations try to update the same secret

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -814,9 +814,9 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 		if (ownerName != "" && ownerName != configurationName) ||
 			(ownerNamespace != "" && ownerNamespace != configuration.Namespace) {
 			errMsg := fmt.Sprintf(
-				"configuration(%s-%s) cannot update secret(%s) whose owner is configuration(%s-%s)",
+				"configuration(namespace: %s ; name: %s) cannot update secret(namespace: %s ; name: %s) whose owner is configuration(namespace: %s ; name: %s)",
 				configuration.Namespace, configurationName,
-				name,
+				gotSecret.Namespace, name,
 				ownerNamespace, ownerName,
 			)
 			return nil, errors.New(errMsg)

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1240,7 +1240,7 @@ func TestGetTFOutputs(t *testing.T) {
 			},
 			want: want{
 				property: nil,
-				errMsg:   "configuration(default-configuration6) cannot update secret(connection-secret-e) whose owner is configuration(default-configuration5)",
+				errMsg:   "configuration(namespace: default ; name: configuration6) cannot update secret(namespace: default ; name: connection-secret-e) whose owner is configuration(namespace: default ; name: configuration5)",
 			},
 		},
 		"update a connectionSecret belong to another configuration(same name but different namespace": {
@@ -1252,7 +1252,7 @@ func TestGetTFOutputs(t *testing.T) {
 			},
 			want: want{
 				property: nil,
-				errMsg:   "configuration(b-configuration6) cannot update secret(connection-secret-e) whose owner is configuration(a-configuration6)",
+				errMsg:   "configuration(namespace: b ; name: configuration6) cannot update secret(namespace: default ; name: connection-secret-e) whose owner is configuration(namespace: a ; name: configuration6)",
 			},
 		},
 		"update a connectionSecret without owner labels": {


### PR DESCRIPTION
Update the error string reported when different configurations try to update the same secret in `getTFOutputs` function.

Signed-off-by: loheagn <loheagn@icloud.com>