### PR TITLE
Support force deletion of Configuration

### DIFF
--- a/api/v1beta2/configuration_types.go
+++ b/api/v1beta2/configuration_types.go
@@ -73,6 +73,10 @@ type BaseConfigurationSpec struct {
 
 	// Region is cloud provider's region. It will override the region in the region field of ProviderReference
 	Region string `json:"customRegion,omitempty"`
+
+	// ForceDelete will force delete Configuration no matter which state it is or whether it has provisioned some resources
+	// It will help delete Configuration in unexpected cases.
+	ForceDelete *bool `json:"forceDelete,omitempty"`
 }
 
 // ConfigurationStatus defines the observed state of Configuration

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -212,6 +212,11 @@ spec:
                 description: DeleteResource will determine whether provisioned cloud
                   resources will be deleted when CR is deleted
                 type: boolean
+              forceDelete:
+                description: ForceDelete will force delete Configuration no matter
+                  which state it is or whether it has provisioned some resources It
+                  will help delete Configuration in unexpected cases.
+                type: boolean
               hcl:
                 description: HCL is the Terraform HCL type configuration
                 type: string

--- a/controllers/configuration/configuration.go
+++ b/controllers/configuration/configuration.go
@@ -111,8 +111,13 @@ func Get(ctx context.Context, k8sClient client.Client, namespacedName apitypes.N
 }
 
 // IsDeletable will check whether the Configuration can be deleted immediately
-// If deletable, it means no external cloud resources are provisioned
+// If deletable, it means
+// - no external cloud resources are provisioned
+//- it's in force-delete state
 func IsDeletable(ctx context.Context, k8sClient client.Client, configuration *v1beta2.Configuration) (bool, error) {
+	if configuration.Spec.ForceDelete != nil && *configuration.Spec.ForceDelete {
+		return true, nil
+	}
 	if !configuration.Spec.InlineCredentials {
 		providerRef := GetProviderNamespacedName(*configuration)
 		providerObj, err := provider.GetProviderFromConfiguration(ctx, k8sClient, providerRef.Namespace, providerRef.Name)

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1125,6 +1125,19 @@ func TestTerraformDestroy(t *testing.T) {
 		VariableSecretName: "c",
 	}
 
+	r5 := &ConfigurationReconciler{}
+	forceDeleteConfig5 := &v1beta2.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "force-delete-config-5",
+		},
+		Spec: v1beta2.ConfigurationSpec{},
+	}
+	var forceDelete = true
+	forceDeleteConfig5.Spec.ForceDelete = &forceDelete
+	k8sClient5 := fake.NewClientBuilder().WithScheme(s).WithObjects(forceDeleteConfig5).Build()
+	r5.Client = k8sClient5
+
 	type args struct {
 		r             *ConfigurationReconciler
 		namespace     string
@@ -1176,6 +1189,14 @@ func TestTerraformDestroy(t *testing.T) {
 				meta:          meta4,
 			},
 			want: want{},
+		},
+		{
+			name: "force delete configuration",
+			args: args{
+				r:             r5,
+				configuration: forceDeleteConfig5,
+				meta:          &TFConfigurationMeta{},
+			},
 		},
 	}
 	for _, tc := range testcases {
@@ -1331,8 +1352,6 @@ func TestGetTFOutputs(t *testing.T) {
 	k8sClient1 := fake.NewClientBuilder().Build()
 	meta1 := &TFConfigurationMeta{}
 
-	//scheme := runtime.NewScheme()
-	//v1beta2.AddToScheme(scheme)
 	secret2 := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "a",

--- a/examples/random/configuration_force_delete.yaml
+++ b/examples/random/configuration_force_delete.yaml
@@ -1,0 +1,20 @@
+apiVersion: terraform.core.oam.dev/v1beta2
+kind: Configuration
+metadata:
+  name: random-e2e-force-delete
+spec:
+  hcl: |
+    resource "random_id" "server" {
+      byte_length = 8
+    }
+    
+    output "random_id" {
+      value = random_id.server.hex
+
+  inlineCredentials: true
+
+  forceDelete: true
+
+  writeConnectionSecretToRef:
+    name: random-conn
+    namespace: default


### PR DESCRIPTION
Force delete Configuration no matter which state it is or whether it has
provisioned some resources. This feature will help delete Configuration
in unexpected cases.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>
